### PR TITLE
Fix mobile project switching from sidebar

### DIFF
--- a/resources/js/components/NavProjects.vue
+++ b/resources/js/components/NavProjects.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from 'vue';
-import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
 import { todoApi, type Project } from '@/services/todoApi';
 import { realtimeService } from '@/services/realtimeService';
 import { useClientStore } from '@/composables/useClientStore';
 import Icon from '@/components/Icon.vue';
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
-import { usePage } from '@inertiajs/vue3';
+import { router, usePage } from '@inertiajs/vue3';
 const projects = ref<Project[]>([]);
 const groupedProjects = ref<any>(null);
 const { selectedClientId, setClientId } = useClientStore();
+const { isMobile, setOpenMobile } = useSidebar();
 const todosLoaded = ref(false);
 const page = usePage();
 
@@ -234,16 +235,22 @@ const filteredProjects = computed(() => {
 const selectProject = (project: Project) => {
   currentProject.value = project;
   localStorage.setItem('currentProjectId', project.id.toString());
+
+  if (isMobile.value) {
+    setOpenMobile(false);
+  }
   
   // Dispatch custom event for TodoBoard to listen to
   window.dispatchEvent(new CustomEvent('projectSelected', {
     detail: { projectId: project.id }
   }));
-  
 
-  
-  // Navigate to dashboard with project context
-  window.location.href = '/dashboard';
+  if (!isOnDashboard.value) {
+    router.visit('/dashboard', {
+      preserveScroll: false,
+      preserveState: false,
+    });
+  }
 };
 
 const deleteProject = async (project: Project, event: Event) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Close the mobile sidebar drawer immediately after selecting a project.
- Use the existing in-page project selection event on the dashboard instead of forcing a hard reload.
- Navigate to the dashboard with Inertia only when selecting a project from another page.

## Testing
- Passed: `npx eslint resources/js/components/NavProjects.vue`
- Blocked: `npm run build` cannot run in this agent image because `php` is not installed.
- Blocked: `npx vite build` after `npm ci` stops on missing generated Wayfinder files (`resources/js/actions/...`), which are normally produced by the PHP artisan step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-114e7a09-57d8-4388-8c81-44b596e2b29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-114e7a09-57d8-4388-8c81-44b596e2b29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

