### PR TITLE
Add Kanban board actions menu

### DIFF
--- a/app/Http/Controllers/Api/ProjectGroupController.php
+++ b/app/Http/Controllers/Api/ProjectGroupController.php
@@ -8,6 +8,7 @@ use App\Models\ProjectGroup;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
 class ProjectGroupController extends Controller
@@ -107,20 +108,16 @@ class ProjectGroupController extends Controller
             ], 422);
         }
 
-        $defaultGroup = ProjectGroup::query()
-            ->where('project_id', $projectGroup->project_id)
-            ->where('is_default', true)
-            ->first();
+        $todoCount = $projectGroup->todos()->count();
 
-        if ($defaultGroup) {
-            $projectGroup->todos()->update(['project_group_id' => $defaultGroup->id]);
-        }
-
-        $projectGroup->delete();
+        DB::transaction(function () use ($projectGroup): void {
+            $projectGroup->todos()->delete();
+            $projectGroup->delete();
+        });
 
         return response()->json([
             'success' => true,
-            'message' => 'Group deleted successfully',
+            'message' => "Group and {$todoCount} todos deleted successfully",
         ]);
     }
 }

--- a/resources/js/components/ProjectGroupTabs.vue
+++ b/resources/js/components/ProjectGroupTabs.vue
@@ -1,27 +1,68 @@
 <template>
   <div v-if="groups.length > 0" class="mt-2 border-t border-gray-200 dark:border-gray-700 pt-2">
     <div class="flex items-center gap-1.5 overflow-x-auto pb-1">
-      <button
+      <div
         v-for="group in groups"
         :key="group.id"
-        type="button"
-        @click="$emit('select', group)"
+        class="relative inline-flex shrink-0"
         :class="[
-          'inline-flex items-center gap-1.5 shrink-0 px-3 py-1.5 rounded-md text-xs font-medium border transition-colors',
+          'rounded-md border transition-colors',
           currentGroupId === group.id
             ? 'bg-gray-900 text-white border-gray-900 dark:bg-white dark:text-gray-900 dark:border-white'
             : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-700',
         ]"
         :style="currentGroupId === group.id && group.color ? { backgroundColor: group.color, borderColor: group.color } : {}"
       >
-        <span class="truncate max-w-[10rem]">{{ group.name }}</span>
-        <span
-          v-if="group.is_default"
-          class="text-[10px] uppercase tracking-wide opacity-70"
+        <button
+          type="button"
+          @click="$emit('select', group)"
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium"
         >
-          default
-        </span>
-      </button>
+          <span class="truncate max-w-[10rem]">{{ group.name }}</span>
+          <span
+            v-if="group.is_default"
+            class="text-[10px] uppercase tracking-wide opacity-70"
+          >
+            default
+          </span>
+        </button>
+
+        <button
+          v-if="!readOnly"
+          type="button"
+          @click.stop="toggleMenu(group.id)"
+          class="inline-flex items-center justify-center border-l border-current/20 px-1.5 text-current/80 hover:text-current focus:outline-none focus:ring-2 focus:ring-blue-500"
+          :aria-expanded="openMenuGroupId === group.id"
+          :aria-label="t('todos.project_groups.board_actions')"
+          :title="t('todos.project_groups.board_actions')"
+        >
+          <Icon name="ChevronDown" class="w-3.5 h-3.5" />
+        </button>
+
+        <div
+          v-if="openMenuGroupId === group.id"
+          class="absolute right-0 top-full z-30 mt-1 w-40 overflow-hidden rounded-md border border-gray-200 bg-white py-1 text-gray-700 shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          @click.stop
+        >
+          <button
+            type="button"
+            @click="emitAction('edit', group)"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            <Icon name="Edit3" class="w-3.5 h-3.5" />
+            {{ t('common.edit') }}
+          </button>
+          <button
+            v-if="!group.is_default"
+            type="button"
+            @click="emitAction('delete', group)"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/30"
+          >
+            <Icon name="Trash2" class="w-3.5 h-3.5" />
+            {{ t('common.delete') }}
+          </button>
+        </div>
+      </div>
 
       <button
         v-if="!readOnly"
@@ -40,6 +81,7 @@
 <script setup lang="ts">
 import Icon from '@/components/Icon.vue';
 import type { ProjectGroup } from '@/services/projectGroupApi';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 defineProps<{
@@ -48,10 +90,39 @@ defineProps<{
   readOnly?: boolean;
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
   select: [group: ProjectGroup];
   create: [];
+  edit: [group: ProjectGroup];
+  delete: [group: ProjectGroup];
 }>();
 
 const { t } = useI18n();
+const openMenuGroupId = ref<number | null>(null);
+
+const toggleMenu = (groupId: number) => {
+  openMenuGroupId.value = openMenuGroupId.value === groupId ? null : groupId;
+};
+
+const emitAction = (action: 'edit' | 'delete', group: ProjectGroup) => {
+  openMenuGroupId.value = null;
+  if (action === 'edit') {
+    emit('edit', group);
+    return;
+  }
+
+  emit('delete', group);
+};
+
+const closeMenu = () => {
+  openMenuGroupId.value = null;
+};
+
+onMounted(() => {
+  document.addEventListener('click', closeMenu);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', closeMenu);
+});
 </script>

--- a/resources/js/components/TodoBoard.vue
+++ b/resources/js/components/TodoBoard.vue
@@ -185,6 +185,8 @@
             :read-only="props.isReadOnly"
             @select="selectProjectGroup"
             @create="openCreateGroupModal"
+            @edit="openEditGroupModal"
+            @delete="deleteProjectGroup"
           />
 
           <!-- Create Project Button (only shown when no project is selected and not at FREE limit) -->
@@ -685,6 +687,46 @@
       </div>
     </div>
 
+    <div v-if="showEditGroup && editingGroup" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" @click="closeEditGroupModal">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full" @click.stop>
+        <div class="p-6">
+          <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ t('todos.project_groups.edit_group') }}</h2>
+            <button @click="closeEditGroupModal" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+              <Icon name="X" class="w-6 h-6" />
+            </button>
+          </div>
+          <form @submit.prevent="saveProjectGroup" class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ t('todos.project_groups.group_name') }}</label>
+              <input
+                v-model="editingGroupName"
+                type="text"
+                required
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md dark:bg-gray-700 dark:text-white"
+                :placeholder="t('todos.project_groups.group_name_placeholder')"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ t('projects.color') }}</label>
+              <div class="flex items-center gap-3">
+                <input v-model="editingGroupColor" type="color" class="w-12 h-10 border border-gray-300 dark:border-gray-600 rounded-md cursor-pointer" />
+                <span class="text-sm text-gray-600 dark:text-gray-400">{{ editingGroupColor }}</span>
+              </div>
+            </div>
+            <div class="flex gap-3 pt-2">
+              <button type="submit" class="flex-1 rounded-md px-4 py-2 text-sm font-medium bg-black text-white dark:bg-white dark:text-black">
+                {{ t('common.save') }}
+              </button>
+              <button type="button" @click="closeEditGroupModal" class="flex-1 rounded-md px-4 py-2 text-sm font-medium border border-gray-300 dark:border-gray-600">
+                {{ t('common.cancel') }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
     <!-- Create Project Modal -->
     <div v-if="showCreateProject && !props.isReadOnly" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" @click="showCreateProject = false">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full" @click.stop>
@@ -1056,6 +1098,10 @@ const currentProject = ref<Project | null>(null);
 const projectGroups = ref<ProjectGroup[]>([]);
 const currentGroup = ref<ProjectGroup | null>(null);
 const showCreateGroup = ref(false);
+const showEditGroup = ref(false);
+const editingGroup = ref<ProjectGroup | null>(null);
+const editingGroupName = ref('');
+const editingGroupColor = ref('#3B82F6');
 const newGroup = ref({
   name: '',
   color: '#3B82F6',
@@ -2768,6 +2814,107 @@ const createProjectGroup = async () => {
         type: 'error',
         title: t('todos.project_groups.create_failed'),
         message: t('todos.project_groups.create_failed'),
+      });
+    }
+  }
+};
+
+const openEditGroupModal = (group: ProjectGroup) => {
+  editingGroup.value = group;
+  editingGroupName.value = group.name;
+  editingGroupColor.value = group.color || currentProject.value?.color || '#3B82F6';
+  showEditGroup.value = true;
+};
+
+const closeEditGroupModal = () => {
+  showEditGroup.value = false;
+  editingGroup.value = null;
+  editingGroupName.value = '';
+  editingGroupColor.value = '#3B82F6';
+};
+
+const saveProjectGroup = async () => {
+  if (!editingGroup.value || !editingGroupName.value.trim()) {
+    return;
+  }
+
+  try {
+    const updated = await projectGroupApi.update(editingGroup.value.id, {
+      name: editingGroupName.value.trim(),
+      color: editingGroupColor.value,
+    });
+
+    projectGroups.value = projectGroups.value.map((group) =>
+      group.id === updated.id ? updated : group,
+    );
+
+    if (currentGroup.value?.id === updated.id) {
+      currentGroup.value = updated;
+    }
+
+    closeEditGroupModal();
+
+    if ((window as any).$notify) {
+      (window as any).$notify({
+        type: 'success',
+        title: t('todos.project_groups.update_success'),
+        message: updated.name,
+      });
+    }
+  } catch {
+    if ((window as any).$notify) {
+      (window as any).$notify({
+        type: 'error',
+        title: t('todos.project_groups.update_failed'),
+        message: t('todos.project_groups.update_failed'),
+      });
+    }
+  }
+};
+
+const deleteProjectGroup = async (group: ProjectGroup) => {
+  if (!currentProject.value || group.is_default) {
+    return;
+  }
+
+  if (!window.confirm(t('todos.project_groups.delete_confirm'))) {
+    return;
+  }
+
+  try {
+    await projectGroupApi.delete(group.id);
+
+    const remainingGroups = projectGroups.value.filter((item) => item.id !== group.id);
+    projectGroups.value = remainingGroups;
+
+    if (currentGroup.value?.id === group.id) {
+      const nextGroup = remainingGroups.find((item) => item.is_default) ?? remainingGroups[0] ?? null;
+      currentGroup.value = nextGroup;
+
+      if (nextGroup) {
+        localStorage.setItem(groupStorageKey(currentProject.value.id), nextGroup.id.toString());
+      } else {
+        localStorage.removeItem(groupStorageKey(currentProject.value.id));
+      }
+
+      await loadTodos();
+    }
+
+    window.dispatchEvent(new CustomEvent('todoChanged'));
+
+    if ((window as any).$notify) {
+      (window as any).$notify({
+        type: 'success',
+        title: t('todos.project_groups.delete_success'),
+        message: group.name,
+      });
+    }
+  } catch {
+    if ((window as any).$notify) {
+      (window as any).$notify({
+        type: 'error',
+        title: t('todos.project_groups.delete_failed'),
+        message: t('todos.project_groups.delete_failed'),
       });
     }
   }

--- a/resources/js/locales/en.json
+++ b/resources/js/locales/en.json
@@ -171,11 +171,17 @@
     "project_groups": {
       "add_group": "Add board",
       "create_group": "Create board",
+      "edit_group": "Edit board",
       "group_name": "Board name",
       "group_name_placeholder": "e.g. Sales pipeline, Maintenance",
+      "board_actions": "Board actions",
       "create_success": "Board created",
       "create_failed": "Failed to create board",
-      "delete_confirm": "Delete this board? Tasks will move to the default board.",
+      "update_success": "Board updated",
+      "update_failed": "Failed to update board",
+      "delete_success": "Board deleted",
+      "delete_failed": "Failed to delete board",
+      "delete_confirm": "Delete this board and all todos on it? This cannot be undone.",
       "switch_board": "Switch kanban board"
     },
     "assignee": "Assignee",

--- a/tests/Feature/ProjectGroupControllerTest.php
+++ b/tests/Feature/ProjectGroupControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use App\Models\ProjectGroup;
+use App\Models\Todo;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectGroupControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deleting_non_default_project_group_deletes_its_todos(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::create([
+            'name' => 'Website',
+            'key' => 'WEB',
+            'color' => '#3B82F6',
+            'owner_id' => $user->id,
+        ]);
+        $defaultGroup = ProjectGroup::createDefaultForProject($project);
+        $extraGroup = ProjectGroup::create([
+            'project_id' => $project->id,
+            'name' => 'Extra board',
+            'color' => '#10B981',
+            'viewing_order' => 2,
+            'is_default' => false,
+        ]);
+        $defaultTodo = Todo::create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'project_group_id' => $defaultGroup->id,
+            'title' => 'Keep me',
+            'priority' => 'Medium',
+            'type' => 'Task',
+            'status' => 'todo',
+        ]);
+        $deletedTodo = Todo::create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'project_group_id' => $extraGroup->id,
+            'title' => 'Delete me',
+            'priority' => 'Medium',
+            'type' => 'Task',
+            'status' => 'todo',
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->deleteJson("/api/project-groups/{$extraGroup->id}");
+
+        $response->assertOk()
+            ->assertJson([
+                'success' => true,
+                'message' => 'Group and 1 todos deleted successfully',
+            ]);
+
+        $this->assertDatabaseMissing('taskit_project_groups', ['id' => $extraGroup->id]);
+        $this->assertDatabaseMissing('taskit_todos', ['id' => $deletedTodo->id]);
+        $this->assertDatabaseHas('taskit_project_groups', ['id' => $defaultGroup->id]);
+        $this->assertDatabaseHas('taskit_todos', ['id' => $defaultTodo->id]);
+    }
+
+    public function test_default_project_group_cannot_be_deleted(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::create([
+            'name' => 'Website',
+            'key' => 'WEB',
+            'color' => '#3B82F6',
+            'owner_id' => $user->id,
+        ]);
+        $defaultGroup = ProjectGroup::createDefaultForProject($project);
+
+        $response = $this
+            ->actingAs($user)
+            ->deleteJson("/api/project-groups/{$defaultGroup->id}");
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'success' => false,
+                'message' => 'The default board cannot be deleted.',
+            ]);
+
+        $this->assertDatabaseHas('taskit_project_groups', ['id' => $defaultGroup->id]);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add per-board dropdown actions for editing and deleting Kanban boards
- Add board rename modal and destructive delete flow in the Kanban board UI
- Delete todos on a deleted non-default board in the API and cover it with feature tests

## Testing
- `npm run build`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=ProjectGroupControllerTest` (passes with warnings about missing local `.env` in this environment)
- `npx vue-tsc --noEmit` (fails in existing generated Wayfinder/Filament files: `resources/js/actions/Filament/Actions/Exports/Http/Controllers/DownloadExport.ts` and `resources/js/routes/filament/exports/index.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f8e3d38-bf03-48e0-bf08-5e3159d81815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f8e3d38-bf03-48e0-bf08-5e3159d81815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

